### PR TITLE
fuzzywuzzy is now thefuzz

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wajig (4.0.4) UNRELEASED; urgency=medium
+
+  * The fuzzywuzzy Python library has been renamed, it is now thefuzz.
+
+ -- Edward Betts <edward@4angle.com>  Sun, 06 Nov 2022 15:31:19 +0000
+
 wajig (4.0.3) unstable; urgency=low
 
   * Updated setup.py to make fuzzywuzzy conditional on Debian

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Graham Williams <Graham.Williams@togaware.com>
 Uploaders: Dirk Eddelbuettel <edd@debian.org>
 Build-Depends: dh-python,
 	       python3-setuptools,
-	       python3-fuzzywuzzy,
+	       python3-thefuzz,
 	       python3-all,
 	       debhelper-compat (= 13),
 	       python3-apt,
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          aptitude,
          dpkg (>= 1.16.2),
          python3-apt (>= 0.8.9),
-	 python3-fuzzywuzzy
+	 python3-thefuzz,
 Suggests: debconf,
           reportbug,
           apt-move,

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ setup(
         # 20211026 Debian does not have rapidfuzz. Checking for
         # DEB_BUILD_ARCH in the environ may be robust for checking if
         # this is a Debian build. If it's Debian, use the debian
-        # packaged fuzzywuzzy, else use the quicker rapidfuzz. Note
+        # packaged thefuzz, else use the quicker rapidfuzz. Note
         # that wajig/util.py tries rapidfuzz first, and utilises it if
-        # installed, otherwise falls back to fuzzywuzzy.
-        'fuzzywuzzy' if 'DEB_BUILD_ARCH' in environ else 'rapidfuzz',
+        # installed, otherwise falls back to thefuzz.
+        'thefuzz' if 'DEB_BUILD_ARCH' in environ else 'rapidfuzz',
         'python-Levenshtein',
     ],
     include_package_data=True,

--- a/wajig/shell.py
+++ b/wajig/shell.py
@@ -21,7 +21,7 @@ def main():
 
     # 20211030 Start exploring implementation of completer.
     #
-    # from fuzzywuzzy import process as fuzzyprocess
+    # from thefuzz import process as fuzzyprocess
     # import rlcompleter
     #
     # def completer(text, state):

--- a/wajig/util.py
+++ b/wajig/util.py
@@ -16,18 +16,18 @@ import apt_pkg
 import wajig.perform as perform
 
 # 20211026 Debian does not have the quicker rapidfuzz, so fall back to
-# fuzzywuzzy. Both have the same interface.
+# thefuzz. Both have the same interface.
 
 # 20211026 Debian build fails with the exception here for some
 # reason. When building for Debian comment out the try and retain just
-# the fuzzywuzzy import.
+# the thefuzz import.
 
 try:
     from rapidfuzz import fuzz
     from rapidfuzz import process as fuzzprocess
 except ImportError:
-    from fuzzywuzzy import fuzz
-    from fuzzywuzzy import process as fuzzprocess
+    from thefuzz import fuzz
+    from thefuzz import process as fuzzprocess
 
 # -----------------------------------------------------------------------
 # CONSTANTS


### PR DESCRIPTION
The fuzzywuzzy Python library has been renamed, it is now thefuzz.
